### PR TITLE
Up minimal PHP version to 7.2 and integrate CodeStype checking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,6 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         php: ['7.2', '7.3', '7.4']
         include:
           - php: '7.2'
-            laravel: '5.7'
-          - php: '7.2'
-            laravel: '5.8'
-          - php: '7.2'
-            laravel: '6.*'
-          - php: '7.2'
             setup: 'basic'
             coverage: 'true'
           - php: '7.4'
@@ -64,10 +58,6 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
       - name: Install basic Composer dependencies
         if: matrix.setup == 'basic'
         run: composer update --prefer-dist --no-interaction --no-suggest
-
-      - name: Install Laravel ${{ matrix.laravel }}
-        if: matrix.laravel != 'default'
-        run: composer require --dev --update-with-dependencies --prefer-dist --no-interaction --no-suggest laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel/laravel -e phpunit/phpunit -e phpstan/phpstan

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         run: composer update --prefer-dist --no-interaction --no-suggest
 
       - name: Show most important packages versions
-        run: composer info | grep -e laravel/laravel -e phpunit/phpunit -e phpstan/phpstan
+        run: composer info | grep -e illuminate -e spiral -e phpunit/phpunit -e phpstan/phpstan
 
       - name: Execute tests
         if: matrix.coverage != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
       matrix:
         setup: ['basic', 'lowest']
         php: ['7.2', '7.3', '7.4']
-        laravel: 'default'
+        laravel: ['default']
         include:
           - php: '7.2'
             laravel: '5.8'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         run: composer update --prefer-dist --no-interaction --no-suggest
 
       - name: Show most important packages versions
-        run: composer info | grep -e illuminate -e spiral -e phpunit/phpunit -e phpstan/phpstan
+        run: composer info | grep -e laravel -e spiral -e phpunit/phpunit -e phpstan/phpstan
 
       - name: Execute tests
         if: matrix.coverage != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,16 +10,21 @@ on:
 
 jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-actions>
   tests:
-    name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup
+    name: PHP ${{ matrix.php }} (${{ matrix.setup }} setup, laravel "${{ matrix.laravel }}")
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         setup: ['basic', 'lowest']
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4']
+        laravel: 'default'
         include:
-          - php: '7.1'
+          - php: '7.2'
+            laravel: '5.8'
+          - php: '7.2'
+            laravel: '6.*'
+          - php: '7.2'
             setup: 'basic'
             coverage: 'true'
           - php: '7.4'
@@ -59,6 +64,10 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         if: matrix.setup == 'basic'
         run: composer update --prefer-dist --no-interaction --no-suggest
 
+      - name: Install basic Composer dependencies
+        if: matrix.laravel != 'default'
+        run: composer require --dev --update-with-dependencies --prefer-dist --no-interaction --no-suggest laravel/laravel "${{ matrix.laravel }}"
+
       - name: Show most important packages versions
         run: composer info | grep -e laravel/laravel -e phpunit/phpunit -e phpstan/phpstan
 
@@ -76,3 +85,38 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/clover.xml
           fail_ci_if_error: false
+
+  cs-check:
+    name: Check Code Style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: 7.4
+          extensions: mbstring
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer 'hirak/prestissimo' package
+        run: composer global require hirak/prestissimo --update-no-dev
+
+      - name: Install Composer dependencies
+        run: composer update --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute check
+        run: composer cs-check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-actions>
   tests:
-    name: PHP ${{ matrix.php }} (${{ matrix.setup }} setup, laravel "${{ matrix.laravel }}")
+    name: PHP ${{ matrix.php }} (${{ matrix.setup }} setup)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -18,8 +18,9 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
       matrix:
         setup: ['basic', 'lowest']
         php: ['7.2', '7.3', '7.4']
-        laravel: ['default']
         include:
+          - php: '7.2'
+            laravel: '5.7'
           - php: '7.2'
             laravel: '5.8'
           - php: '7.2'
@@ -64,7 +65,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         if: matrix.setup == 'basic'
         run: composer update --prefer-dist --no-interaction --no-suggest
 
-      - name: Install basic Composer dependencies
+      - name: Install Laravel ${{ matrix.laravel }}
         if: matrix.laravel != 'default'
         run: composer require --dev --update-with-dependencies --prefer-dist --no-interaction --no-suggest laravel/laravel "${{ matrix.laravel }}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v3.4.0
+
+### Added
+
+- Source code style checking using `spiral/code-style` package [#3]
+
+### Changed
+
+- Minimal required PHP version now is `7.2` [#3]
+
+[#3]:https://github.com/spiral/roadrunner-laravel/issues/3
+
 ## v3.3.0
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,0 @@
-# TODO
-
-> Will be removed before first release
-
-- [ ] Get codecov token for repo (`CODECOV_TOKEN`)
-- [ ] Refactor composer scripts (like `test-cover`)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-mbstring": "*",
         "illuminate/contracts": "^5.5 || ~6.0 || ~7.0",
         "illuminate/support": "^5.5 || ~6.0 || ~7.0",
@@ -32,7 +32,8 @@
         "laravel/laravel": "^5.5 || ~6.0 || ~7.0",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "~0.12",
-        "phpunit/phpunit": "^6.4 || ~7.5"
+        "phpunit/phpunit": "^6.4 || ~7.5",
+        "spiral/code-style": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -51,6 +52,8 @@
         "phpunit": "@php ./vendor/bin/phpunit --no-coverage --colors=always",
         "phpunit-cover": "@php ./vendor/bin/phpunit",
         "phpstan": "@php ./vendor/bin/phpstan analyze -c ./phpstan.neon.dist --no-progress --ansi",
+        "cs-check": "@php ./vendor/bin/spiral-cs check ./bin ./src ./tests --ansi",
+        "cs-fix": "@php ./vendor/bin/spiral-cs fix ./bin ./src ./tests --ansi",
         "test": [
             "@phpstan",
             "@phpunit"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes or No
| New feature?  | Yes or No

## Description

### Added

- Source code style checking using `spiral/code-style` package

### Changed

- Minimal required PHP version now is `7.2`

Closes #3

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add version header `## UNRELEASED`, if it does not exists
* Add description under `Added`/`Changed`/`Fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
