### PR TITLE
PHP 8.x is supported now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, pdo, pdo_sqlite, sqlite3 # definition is required for php 7.4
+          extensions: mbstring, pdo, pdo_sqlite, sqlite3, xdebug # definition is required for php 7.4
 
       - name: Get Composer Cache Directory # Docs: <https://github.com/actions/cache/blob/master/examples.md#php---composer>
         id: composer-cache
@@ -69,6 +69,8 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
 
       - name: Execute tests with code coverage
         if: matrix.coverage == 'true'
+        env:
+          XDEBUG_MODE: coverage
         run: composer test-cover
 
       - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
@@ -106,6 +108,4 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         run: composer require 'spiral/code-style:^1.0' -n --no-progress --prefer-dist # `--ignore-platform-reqs` is required only for PHP 8.0
 
       - name: Execute check
-        env:
-          XDEBUG_MODE: coverage
         run: php ./vendor/bin/spiral-cs check ./bin ./src ./tests --ansi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,11 +54,11 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
 
       - name: Install lowest Composer dependencies
         if: matrix.setup == 'lowest'
-        run: composer update --prefer-dist --no-interaction --prefer-lowest --ansi
+        run: composer update --prefer-dist --no-interaction --prefer-lowest --no-progress --ansi
 
       - name: Install basic Composer dependencies
         if: matrix.setup == 'basic'
-        run: composer update --prefer-dist --no-interaction --ansi
+        run: composer update --prefer-dist --no-interaction --no-progress --ansi
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel -e spiral -e phpunit/phpunit -e phpstan/phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,10 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         setup: ['basic', 'lowest']
         php: ['7.3', '7.4', '8.0']
         include:
-          - php: '7.2'
+          - php: '7.3'
             setup: 'basic'
             coverage: 'true'
-          - php: '7.4'
+          - php: '8.0'
             setup: 'basic'
             coverage: 'true'
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
       fail-fast: false
       matrix:
         setup: ['basic', 'lowest']
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
         include:
           - php: '7.2'
             setup: 'basic'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,4 +106,6 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         run: composer require 'spiral/code-style:^1.0' -n --no-progress --prefer-dist # `--ignore-platform-reqs` is required only for PHP 8.0
 
       - name: Execute check
+        env:
+          XDEBUG_MODE: coverage
         run: php ./vendor/bin/spiral-cs check ./bin ./src ./tests --ansi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ on:
 jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-actions>
   tests:
     name: PHP ${{ matrix.php }} (${{ matrix.setup }} setup)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -80,7 +80,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
 
   cs-check:
     name: Check Code Style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -102,8 +102,8 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install Composer dependencies
-        run: composer update --prefer-dist --no-interaction --ansi
+      - name: Install required Composer packages
+        run: composer global require 'spiral/code-style:^1.0' -n --no-progress --prefer-dist # `--ignore-platform-reqs` is required only for PHP 8.0
 
       - name: Execute check
-        run: composer cs-check
+        run: spiral-cs check ./bin ./src ./tests --ansi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         if: matrix.setup == 'basic'
         run: composer update --prefer-dist --no-interaction --no-progress --ansi
 
-      - name: Show most important packages versions
+      - name: Show most important package versions
         run: composer info | grep -e laravel -e spiral -e phpunit/phpunit -e phpstan/phpstan
 
       - name: Execute tests
@@ -103,7 +103,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install required Composer packages
-        run: composer global require 'spiral/code-style:^1.0' -n --no-progress --prefer-dist # `--ignore-platform-reqs` is required only for PHP 8.0
+        run: composer require 'spiral/code-style:^1.0' -n --no-progress --prefer-dist # `--ignore-platform-reqs` is required only for PHP 8.0
 
       - name: Execute check
-        run: spiral-cs check ./bin ./src ./tests --ansi
+        run: php ./vendor/bin/spiral-cs check ./bin ./src ./tests --ansi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Composer `2.x` is supported now
 - Minimal required PHP version now is `7.3` (`7.2` security support ended January 1st, 2021)
+- Dev-dependency `mockery/mockery` minimal required version changed from `^1.3.1` to `^1.3.2`
+- Dev-dependency `phpstan/phpstan` minimal required version changed from `~0.12` to `~0.12.34`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## UNRELEASED
 
+### Added
+
+- Support PHP `8.x`
+
 ### Changed
 
 - Composer `2.x` is supported now
-- Minimal required PHP version now is `7.3` (`7.2` security support ended 1 Jan 2021)
+- Minimal required PHP version now is `7.3` (`7.2` security support ended January 1st, 2021)
+
+### Removed
+
+- Code-style checking and fixing for local development (packages `spiral/code-style` and `friendsofphp/php-cs-fixer` does not supports PHP `8.x`), but using GitHub this actions keep running
 
 ## v3.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Composer `2.x` is supported now
+- Minimal required PHP version now is `7.3` (`7.2` security support ended 1 Jan 2021)
 
 ## v3.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## UNRELEASED
+## v3.7.0
 
 ### Added
 
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Removed
 
-- Code-style checking and fixing for local development (packages `spiral/code-style` and `friendsofphp/php-cs-fixer` does not supports PHP `8.x`), but using GitHub this actions keep running
+- Code-style checking and fixing for local development (packages `spiral/code-style` and `friendsofphp/php-cs-fixer` does not supports PHP `8.x`), but using GitHub this actions still running
 
 ## v3.6.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x \
     # install xdebug (for testing with code coverage), but do not enable it
     && pecl install xdebug-3.0.0 1>/dev/null \
     && apk del .build-deps \
-    && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/{repo,files} \
+    && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/repo ${COMPOSER_HOME}/cache/files \
     && ln -s /usr/bin/composer /usr/bin/c \
     && composer --version \
     && php -v \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.5-alpine
+FROM php:8.0-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
@@ -8,11 +8,10 @@ RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.6 1>/dev/null \
+    && pecl install xdebug-3.0.0 1>/dev/null \
     && apk del .build-deps \
-    && mkdir -p /src ${COMPOSER_HOME}/cache/{repo,files} \
+    && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/{repo,files} \
     && ln -s /usr/bin/composer /usr/bin/c \
-    && chmod -R 777 ${COMPOSER_HOME} \
     && composer --version \
     && php -v \
     && php -m

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: ## Execute php tests and linters
 	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
 	docker-compose run $(RUN_APP_ARGS) app sh

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ latest: clean ## Install latest php dependencies
 	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist
 
 lowest: clean ## Install lowest php dependencies
 	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-lowest

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
         "mockery/mockery": "^1.3.1",
         "phpstan/phpstan": "~0.12",
-        "phpunit/phpunit": "^8.0 || ^9.3",
-        "spiral/code-style": "^1.0"
+        "phpunit/phpunit": "^8.0 || ^9.3"
     },
     "autoload": {
         "psr-4": {
@@ -52,8 +51,6 @@
         "phpunit": "@php ./vendor/bin/phpunit --no-coverage --colors=always",
         "phpunit-cover": "@php ./vendor/bin/phpunit",
         "phpstan": "@php ./vendor/bin/phpstan analyze -c ./phpstan.neon.dist --no-progress --ansi",
-        "cs-check": "@php ./vendor/bin/spiral-cs check ./bin ./src ./tests --ansi",
-        "cs-fix": "@php ./vendor/bin/spiral-cs fix ./bin ./src ./tests --ansi",
         "test": [
             "@phpstan",
             "@phpunit"

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "ext-pdo_sqlite": "*",
         "ext-sqlite3": "*",
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
-        "mockery/mockery": "^1.3.1",
-        "phpstan/phpstan": "~0.12",
+        "mockery/mockery": "^1.3.2",
+        "phpstan/phpstan": "~0.12.34",
         "phpunit/phpunit": "^8.0 || ^9.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3 || ^8.0",
         "ext-mbstring": "*",
         "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,27 +11,31 @@
          processIsolation="false"
          forceCoversAnnotation="true"
          stopOnFailure="false">
+
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+
+    <coverage includeUncoveredFiles="false" processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <!--log type="coverage-html" target="./coverage/html"/-->
-        <log type="coverage-xml" target="./coverage/xml"/>
-        <log type="coverage-clover" target="./coverage/clover.xml"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-    </logging>
+        </include>
+        <exclude>
+            <directory>./vendor</directory>
+            <directory>./tests</directory>
+        </exclude>
+        <report>
+            <clover outputFile="./coverage/clover.xml"/>
+            <html outputDirectory="./coverage/html"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+            <xml outputDirectory="./coverage/xml"/>
+        </report>
+    </coverage>
+
     <php>
-        <env name="APP_KEY" value="base64:+hY09mlBag/d7Qhq2SjE/i2iUzZBS1dGObLqcHZU2Ac="/>
-        <env name="APP_URL" value="http://unit-test"/>
+        <server name="APP_KEY" value="base64:+hY09mlBag/d7Qhq2SjE/i2iUzZBS1dGObLqcHZU2Ac=" force="true"/>
+        <server name="APP_URL" value="http://unit-test" force="true"/>
     </php>
 </phpunit>


### PR DESCRIPTION
## Description

### Changed

- Minimal required PHP version now is `7.3` (`7.2` security support ended 1 Jan 2021)

Fixes #24

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add version header `## UNRELEASED`, if it does not exists
* Add description under `Added`/`Changed`/`Fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
