### PR TITLE
Fix Symfony File::move()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Fixed
+
+- Symfony uploaded file moving (`FixSymfonyFileMovingListener` was added for this) [#43]
+
+[#43]:https://github.com/spiral/roadrunner-laravel/issues/43
+
 ## v5.0.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "spiral/roadrunner-laravel",
     "type": "library",
-    "description": "RoadRunner bridge for Laravel applications",
+    "description": "RoadRunner: Bridge for Laravel applications",
     "keywords": [
         "laravel",
         "bridge",

--- a/fixes/fix-symfony-file-moving.php
+++ b/fixes/fix-symfony-file-moving.php
@@ -19,8 +19,8 @@ namespace Symfony\Component\HttpFoundation\File {
      * @param string $from The filename of the uploaded file
      * @param string $to   The destination of the moved file
      *
-     * @return bool If filename is a valid file, but cannot be moved for some reason, no action will occur, and will
-     * return false.
+     * @return bool If filename is a valid file, but cannot be moved for some
+     *              reason, no action will occur, and will return false.
      *
      * @see   \Symfony\Component\HttpFoundation\File\UploadedFile::move
      *

--- a/fixes/fix-symfony-file-moving.php
+++ b/fixes/fix-symfony-file-moving.php
@@ -8,28 +8,29 @@ namespace Symfony\Component\HttpFoundation\File {
      * ***************************************************************************
      * *******                                                             *******
      * *******        THIS FUNCTION OVERLOADING IS NECESSARY MEASURE       *******
-     * *******   https://github.com/avto-dev/roadrunner-laravel/issues/10  *******
-     * *******        https://github.com/spiral/roadrunner/issues/133      *******
+     * *******    https://github.com/spiral/roadrunner-laravel/issues/43   *******
      * *******                                                             *******
      * ***************************************************************************.
      *
-     * Tells whether the file was uploaded via HTTP POST.
+     * Moves an uploaded file to a new location.
      *
-     * @link  https://php.net/manual/en/function.is-uploaded-file.php
+     * @link  https://php.net/manual/en/function.move-uploaded-file.php
      *
-     * @param string $filename The filename being checked
+     * @param string $from The filename of the uploaded file
+     * @param string $to   The destination of the moved file
      *
-     * @return bool always true
+     * @return bool If filename is a valid file, but cannot be moved for some reason, no action will occur, and will
+     * return false.
      *
-     * @see   \Symfony\Component\HttpFoundation\File\UploadedFile::isValid
+     * @see   \Symfony\Component\HttpFoundation\File\UploadedFile::move
      *
      * @since 4.0.3
      * @since 5.0
      * @since 7.0
      * @since 8.0
      */
-    function is_uploaded_file(string $filename): bool
+    function move_uploaded_file(string $from, string $to): bool
     {
-        return true;
+        return \is_file($from) && \rename($from, $to);
     }
 }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -15,6 +15,7 @@ final class Defaults
     {
         return [
             Listeners\FixSymfonyFileValidationListener::class,
+            Listeners\FixSymfonyFileMovingListener::class,
             Listeners\WarmInstancesListener::class,
         ];
     }

--- a/src/Listeners/FixSymfonyFileMovingListener.php
+++ b/src/Listeners/FixSymfonyFileMovingListener.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerLaravel\Listeners;
+
+/**
+ * @link https://github.com/spiral/roadrunner-laravel/issues/43
+ */
+class FixSymfonyFileMovingListener implements ListenerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($event): void
+    {
+        if (!\function_exists('\\Symfony\\Component\\HttpFoundation\\File\\move_uploaded_file')) {
+            require __DIR__ . '/../../fixes/fix-symfony-file-moving.php';
+        }
+    }
+}

--- a/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
+++ b/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
@@ -31,7 +31,7 @@ class FixSymfonyFileMovingListenerTest extends AbstractListenerTestCase
         $this->assertTrue($function_location($old_file_path, $new_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random()));
         $this->assertFalse($function_location($tmp_dir . DIRECTORY_SEPARATOR . Str::random(), $tmp_dir . DIRECTORY_SEPARATOR . Str::random()));
         $this->assertFileExists($new_file_path);
-        $this->assertFileDoesNotExist($old_file_path);
+        $this->assertFileNotExists($old_file_path);
     }
 
     /**

--- a/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
+++ b/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
@@ -30,12 +30,13 @@ class FixSymfonyFileMovingListenerTest extends AbstractListenerTestCase
         $old_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
         $new_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
         \file_put_contents($old_file_path, '');
+        $this->assertFileExists($old_file_path);
         $this->assertTrue($function_location($old_file_path, $new_file_path));
+        $this->assertFileExists($new_file_path);
+        $this->assertFileNotExists($old_file_path);
         $rnd_file_path1 = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
         $rnd_file_path2 = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
         $this->assertFalse($function_location($rnd_file_path1, $rnd_file_path2));
-        $this->assertFileExists($new_file_path);
-        $this->assertFileNotExists($old_file_path);
     }
 
     /**

--- a/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
+++ b/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerLaravel\Tests\Unit\Listeners;
+
+use Illuminate\Support\Str;
+use Spiral\RoadRunnerLaravel\Listeners\FixSymfonyFileMovingListener;
+
+/**
+ * @covers \Spiral\RoadRunnerLaravel\Listeners\FixSymfonyFileMovingListener
+ */
+class FixSymfonyFileMovingListenerTest extends AbstractListenerTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testHandle(): void
+    {
+        $function_location = '\\Symfony\\Component\\HttpFoundation\\File\\move_uploaded_file';
+
+        $this->assertFalse(\function_exists($function_location));
+        $this->assertFalse(\is_uploaded_file('foo'));
+
+        $this->listenerFactory()->handle(new \stdClass());
+
+        $this->assertTrue(\function_exists($function_location));
+
+        $tmp_dir = $this->createTemporaryDirectory();
+        \file_put_contents($old_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random(), '');
+        $this->assertTrue($function_location($old_file_path, $new_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random()));
+        $this->assertFalse($function_location($tmp_dir . DIRECTORY_SEPARATOR . Str::random(), $tmp_dir . DIRECTORY_SEPARATOR . Str::random()));
+        $this->assertFileExists($new_file_path);
+        $this->assertFileDoesNotExist($old_file_path);
+    }
+
+    /**
+     * @return FixSymfonyFileMovingListener
+     */
+    protected function listenerFactory(): FixSymfonyFileMovingListener
+    {
+        return new FixSymfonyFileMovingListener();
+    }
+}

--- a/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
+++ b/tests/Unit/Listeners/FixSymfonyFileMovingListenerTest.php
@@ -27,9 +27,13 @@ class FixSymfonyFileMovingListenerTest extends AbstractListenerTestCase
         $this->assertTrue(\function_exists($function_location));
 
         $tmp_dir = $this->createTemporaryDirectory();
-        \file_put_contents($old_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random(), '');
-        $this->assertTrue($function_location($old_file_path, $new_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random()));
-        $this->assertFalse($function_location($tmp_dir . DIRECTORY_SEPARATOR . Str::random(), $tmp_dir . DIRECTORY_SEPARATOR . Str::random()));
+        $old_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
+        $new_file_path = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
+        \file_put_contents($old_file_path, '');
+        $this->assertTrue($function_location($old_file_path, $new_file_path));
+        $rnd_file_path1 = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
+        $rnd_file_path2 = $tmp_dir . DIRECTORY_SEPARATOR . Str::random();
+        $this->assertFalse($function_location($rnd_file_path1, $rnd_file_path2));
         $this->assertFileExists($new_file_path);
         $this->assertFileNotExists($old_file_path);
     }


### PR DESCRIPTION
## Description

### Fixed

- Symfony uploaded file moving (`FixSymfonyFileMovingListener` was added for this)

Fixes #43

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add version header `## UNRELEASED`, if it does not exists
* Add description under `Added`/`Changed`/`Fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
