### PR TITLE
Added listener `FlushLogContextListener` for the logger context flushing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
       matrix:
         setup: ['basic', 'lowest']
         php: ['7.4', '8.0']
-        rr: ['2.2.1'] # Releases: <https://github.com/spiral/roadrunner-binary/releases>
+        rr: ['2.3.1'] # Releases: <https://github.com/spiral/roadrunner-binary/releases>
         coverage: ['true']
         include:
           - php: '7.4'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Listener `FlushLogContextListener` for the logger context flushing
+
 ## v5.0.2
 
 ### Fixed

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -83,6 +83,7 @@ final class Defaults
     {
         return [
             Listeners\FlushDumperStackListener::class,
+            Listeners\FlushLogContextListener::class,
             Listeners\FlushArrayCacheListener::class,
             Listeners\ResetDatabaseRecordModificationStateListener::class,
             Listeners\ClearInstancesListener::class,

--- a/src/Listeners/FlushLogContextListener.php
+++ b/src/Listeners/FlushLogContextListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerLaravel\Listeners;
+
+use Spiral\RoadRunnerLaravel\Events\Contracts\WithApplication;
+
+/**
+ * @link https://github.com/laravel/octane/blob/1.x/src/Listeners/FlushLogContext.php
+ */
+class FlushLogContextListener implements ListenerInterface
+{
+    use Traits\InvokerTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($event): void
+    {
+        if ($event instanceof WithApplication) {
+            $app = $event->application();
+
+            if (!$app->resolved($log_abstract = 'log')) {
+                return;
+            }
+
+            /** @var \Illuminate\Log\LogManager $log */
+            $log = $app->make($log_abstract);
+
+            /** @var \Illuminate\Log\Logger $logger */
+            $logger = $log->driver();
+
+            /**
+             * Method `withoutContext` for the Logger available since Laravel v8.49.0.
+             *
+             * @link https://github.com/illuminate/log/blob/v8.49.0/Logger.php#L202-L212 Source code (v8.49.0)
+             * @see  \Illuminate\Log\Logger::withoutContext
+             */
+            $this->invokeMethod($logger, 'withoutContext');
+        }
+    }
+}

--- a/src/Listeners/FlushLogContextListener.php
+++ b/src/Listeners/FlushLogContextListener.php
@@ -25,11 +25,11 @@ class FlushLogContextListener implements ListenerInterface
                 return;
             }
 
-            /** @var \Illuminate\Log\LogManager $log */
-            $log = $app->make($log_abstract);
+            /** @var \Illuminate\Log\LogManager $log_manager */
+            $log_manager = $app->make($log_abstract);
 
-            /** @var \Illuminate\Log\Logger $logger */
-            $logger = $log->driver();
+            /** @var \Psr\Log\LoggerInterface|\Illuminate\Log\Logger $logger */
+            $logger = $log_manager->driver();
 
             /**
              * Method `withoutContext` for the Logger available since Laravel v8.49.0.

--- a/tests/Unit/Listeners/FlushLogContextListenerTest.php
+++ b/tests/Unit/Listeners/FlushLogContextListenerTest.php
@@ -23,6 +23,10 @@ class FlushLogContextListenerTest extends AbstractListenerTestCase
 
         $logger = $log_manager->driver();
 
+        if (! \method_exists($logger, 'withoutContext')) {
+            $this->markTestSkipped('Current illuminate/log package version does now supports ::withoutContext()');
+        }
+
         $this->app->instance('log', m::mock($log_manager)
             ->makePartial()
             ->expects('driver')

--- a/tests/Unit/Listeners/FlushLogContextListenerTest.php
+++ b/tests/Unit/Listeners/FlushLogContextListenerTest.php
@@ -39,8 +39,7 @@ class FlushLogContextListenerTest extends AbstractListenerTestCase
                     ->andReturn($logger)
                     ->getMock()
             )
-            ->getMock()
-        );
+            ->getMock());
 
         /** @var m\MockInterface|WithApplication $event_mock */
         $event_mock = m::mock(WithApplication::class)

--- a/tests/Unit/Listeners/FlushLogContextListenerTest.php
+++ b/tests/Unit/Listeners/FlushLogContextListenerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerLaravel\Tests\Unit\Listeners;
+
+use Mockery as m;
+use Spiral\RoadRunnerLaravel\Events\Contracts\WithApplication;
+use Spiral\RoadRunnerLaravel\Listeners\FlushLogContextListener;
+
+/**
+ * @covers \Spiral\RoadRunnerLaravel\Listeners\FlushLogContextListener
+ */
+class FlushLogContextListenerTest extends AbstractListenerTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testHandle(): void
+    {
+        /** @var \Illuminate\Log\LogManager $log_manager */
+        $log_manager = $this->app->make('log');
+
+        $logger = $log_manager->driver();
+
+        $this->app->instance('log', m::mock($log_manager)
+            ->makePartial()
+            ->expects('driver')
+            ->withNoArgs()
+            ->andReturn(
+                m::mock($logger)
+                    ->makePartial()
+                    ->expects('withoutContext')
+                    ->withNoArgs()
+                    ->andReturn($logger)
+                    ->getMock()
+            )
+            ->getMock()
+        );
+
+        /** @var m\MockInterface|WithApplication $event_mock */
+        $event_mock = m::mock(WithApplication::class)
+            ->makePartial()
+            ->expects('application')
+            ->andReturn($this->app)
+            ->getMock();
+
+        $this->listenerFactory()->handle($event_mock);
+    }
+
+    /**
+     * @return FlushLogContextListener
+     */
+    protected function listenerFactory(): FlushLogContextListener
+    {
+        return new FlushLogContextListener();
+    }
+}


### PR DESCRIPTION
## Description

### Added

- Listener `FlushLogContextListener` for the logger context flushing

Related PR: https://github.com/laravel/octane/pull/337

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add version header `## UNRELEASED`, if it does not exists
* Add description under `Added`/`Changed`/`Fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
