### PR TITLE
Fix dumper middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v5.2.1
+
+### Fixed
+
+- Dumper middleware could not to dump large set of responses (such as `Illuminate\Http\JsonResponse`)
+
 ## v5.2.0
 
 ### Added

--- a/src/Dumper/Middleware.php
+++ b/src/Dumper/Middleware.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Spiral\RoadRunnerLaravel\Dumper;
 
 use Closure;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 class Middleware

--- a/tests/Unit/Dumper/MiddlewareTest.php
+++ b/tests/Unit/Dumper/MiddlewareTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Spiral\RoadRunnerLaravel\Tests\Unit\Dumper;
 
 use Illuminate\Support\Str;
-use Illuminate\Http\Response;
 use Illuminate\Routing\Router;
+use Symfony\Component\HttpFoundation\Response;
 use Spiral\RoadRunnerLaravel\Dumper\Middleware;
 
 /**


### PR DESCRIPTION
## Description

### Fixed

- Dumper middleware could not to dump large set of responses (such as `Illuminate\Http\JsonResponse`)

Fixes https://github.com/tarampampam/laravel-roadrunner-in-docker/issues/55

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add version header `## UNRELEASED`, if it does not exists
* Add description under `Added`/`Changed`/`Fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
