### PR TITLE
Translator memory leak fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Added
+
+- Listener `FlushTranslatorCacheListener` for memory leak fixing on `Translator` implementation [#69]
+
+[#69]:https://github.com/spiral/roadrunner-laravel/pull/69
+
 ## v5.4.0
 
 ### Added

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -94,6 +94,7 @@ final class Defaults
             Listeners\FlushDumperStackListener::class,
             Listeners\FlushLogContextListener::class,
             Listeners\FlushArrayCacheListener::class,
+            Listeners\FlushTranslatorCacheListener::class,
             Listeners\ResetDatabaseRecordModificationStateListener::class,
             Listeners\FlushDatabaseQueryLogListener::class,
             Listeners\ClearInstancesListener::class,

--- a/src/Listeners/FlushTranslatorCacheListener.php
+++ b/src/Listeners/FlushTranslatorCacheListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerLaravel\Listeners;
+
+use Illuminate\Translation\Translator;
+use Illuminate\Support\NamespacedItemResolver;
+use Spiral\RoadRunnerLaravel\Events\Contracts\WithApplication;
+
+/**
+ * @link https://github.com/laravel/octane/pull/416/files
+ */
+class FlushTranslatorCacheListener implements ListenerInterface
+{
+    use Traits\InvokerTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle($event): void
+    {
+        if ($event instanceof WithApplication) {
+            $app = $event->application();
+
+            if (! $app->resolved($translator_abstract = 'translator')) {
+                return;
+            }
+
+            /** @var Translator $translator */
+            $translator = $app->make($translator_abstract);
+
+            if ($translator instanceof NamespacedItemResolver) {
+                /**
+                 * Method `flushParsedKeys` for the Translator available since Laravel v8.70.0.
+                 *
+                 * @link https://git.io/JXd0v Source code (v8.70.0)
+                 * @see  Translator::flushParsedKeys()
+                 */
+                if (! $this->invokeMethod($translator, 'flushParsedKeys')) {
+                    $this->setProperty($translator, 'parsed', []);
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Listeners/FlushTranslatorCacheListenerTest.php
+++ b/tests/Unit/Listeners/FlushTranslatorCacheListenerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerLaravel\Tests\Unit\Listeners;
+
+use Mockery as m;
+use Illuminate\Translation\Translator;
+use Spiral\RoadRunnerLaravel\Events\Contracts\WithApplication;
+use Spiral\RoadRunnerLaravel\Listeners\FlushTranslatorCacheListener;
+
+/**
+ * @covers \Spiral\RoadRunnerLaravel\Listeners\FlushTranslatorCacheListener
+ */
+class FlushTranslatorCacheListenerTest extends AbstractListenerTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function testHandle(): void
+    {
+        /** @var Translator $translator */
+        $translator = $this->app->make('translator');
+
+        $translator->setParsedKey('foo::bar.baz', ['foo', 'bar', 'baz']);
+
+        /** @var m\MockInterface|WithApplication $event_mock */
+        $event_mock = m::mock(WithApplication::class)
+            ->makePartial()
+            ->expects('application')
+            ->andReturn($this->app)
+            ->getMock();
+
+        $this->assertNotEmpty($this->getProperty($translator, 'parsed'));
+
+        $this->listenerFactory()->handle($event_mock);
+
+        $this->assertEmpty($this->getProperty($translator, 'parsed'));
+    }
+
+    /**
+     * @return FlushTranslatorCacheListener
+     */
+    protected function listenerFactory(): FlushTranslatorCacheListener
+    {
+        return new FlushTranslatorCacheListener();
+    }
+}


### PR DESCRIPTION
## Description

### Added

- Listener `FlushTranslatorCacheListener` for memory leak fixing on `Translator` implementation

Related PR: https://github.com/laravel/octane/pull/416

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add version header `## UNRELEASED`, if it does not exists
* Add description under `Added`/`Changed`/`Fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
