### PR TITLE
fix: add Symfony Console 8.0 compatibility for add() removal

### DIFF
--- a/bin/rr-worker
+++ b/bin/rr-worker
@@ -72,6 +72,10 @@ $app = new ApplicationAlias(
     InstalledVersions::getPrettyVersion('roadrunner-php/laravel-bridge') ?? 'unknown',
 );
 
-$app->add(new StartCommand($basePath));
+$command = new StartCommand($basePath);
+
+\method_exists($app, 'addCommand')
+    ? $app->addCommand($command)
+    : $app->add($command);
 
 $app->run();


### PR DESCRIPTION


## Description

bin/rr-worker crashes on every request with Call to undefined method Symfony\Component\Console\Application::add() when used with symfony/console ^8.0 (pulled in by Laravel 13).

`Application::add()` was removed in Symfony Console 8.0 and renamed to `addCommand()`. The fix checks via method_exists() which method is available and calls accordingly, maintaining backward compatibility with older Symfony versions.

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [ ] I have made changes in `CHANGELOG.md` file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved command registration logic for better runtime compatibility, ensuring consistent behavior across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->