### PR TITLE
feat(grpc): support per-service interceptors for gRPC clients

### DIFF
--- a/config/roadrunner.php
+++ b/config/roadrunner.php
@@ -41,6 +41,12 @@ return [
                 //     'interfaces' => [
                 //         GreeterInterface::class,
                 //     ],
+                //     'interceptors' => [
+                //         // Per-service interceptors. Requires the
+                //         // \Spiral\Grpc\Client\Interceptor\ExecuteServiceInterceptors
+                //         // interceptor in the global `interceptors` list above.
+                //         // GreeterClientInterceptor::class,
+                //     ],
                 // ],
                 // [
                 //     'connection' => 'my-secure-grpc-server:9002',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -64,6 +64,7 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
              * @var array<int, array{
              *     connection: non-empty-string,
              *     interfaces: list<class-string>,
+             *     interceptors?: list<class-string<\Spiral\Interceptors\InterceptorInterface>|\Spiral\Core\Container\Autowire<\Spiral\Interceptors\InterceptorInterface>|\Spiral\Interceptors\InterceptorInterface>,
              *     tls?: array{
              *         rootCerts?: non-empty-string|null,
              *         privateKey?: non-empty-string|null,
@@ -90,8 +91,11 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
                 $connection = $service['connection'];
                 /** @var list<class-string> $interfaces */
                 $interfaces = $service['interfaces'];
+                /** @var list<class-string<\Spiral\Interceptors\InterceptorInterface>|\Spiral\Core\Container\Autowire<\Spiral\Interceptors\InterceptorInterface>|\Spiral\Interceptors\InterceptorInterface> $serviceInterceptors */
+                $serviceInterceptors = $service['interceptors'] ?? [];
                 $serviceConfigs[] = new ServiceConfig(
                     connections: new ConnectionConfig($connection, $tls),
+                    interceptors: $serviceInterceptors,
                     interfaces: $interfaces,
                 );
             }
@@ -105,6 +109,5 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
             return new ServiceClientProvider($config, $this->app->make(FactoryInterface::class));
         });
-
     }
 }


### PR DESCRIPTION
## Summary

- Read the optional `interceptors` array from each entry in `roadrunner.grpc.clients.services` and pass it to `ServiceConfig` via the named `interceptors:` argument, enabling per-service interceptor pipelines (in addition to the existing global ones declared under `roadrunner.grpc.clients.interceptors`).
- Defaults to an empty list when the key is omitted, so existing configurations keep working unchanged.
- Documents the new key in the published `config/roadrunner.php` example, including the reminder that `\Spiral\Grpc\Client\Interceptor\ExecuteServiceInterceptors` must be present in the global pipeline for service-specific interceptors to actually run.

## Motivation

`Spiral\Grpc\Client\Config\ServiceConfig` already accepts `interceptors`, but the Laravel bridge only wired up `connections` and `interfaces`. That made it impossible to attach an interceptor (e.g. auth, logging, tracing) to a single gRPC service without applying it globally. This change exposes that knob through the package's config without altering the public API surface.

## Example

```php
'clients' => [
    'interceptors' => [
        \Spiral\Grpc\Client\Interceptor\ExecuteServiceInterceptors::class,
    ],
    'services' => [
        [
            'connection' => 'greeter:9001',
            'interfaces' => [GreeterInterface::class],
            'interceptors' => [
                GreeterAuthInterceptor::class,
            ],
        ],
    ],
],
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * gRPC client configuration now supports per-service interceptors, allowing custom request and response handling logic for individual services.

* **Documentation**
  * Added configuration example demonstrating per-service interceptor setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-php/laravel-bridge/pull/170)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->