### PR TITLE
fix(queue): return raw task payload string from RoadRunnerJob::getRawBody

### DIFF
--- a/src/Queue/RoadRunnerJob.php
+++ b/src/Queue/RoadRunnerJob.php
@@ -28,7 +28,7 @@ class RoadRunnerJob extends Job implements JobContract
 
     public function getRawBody(): string
     {
-        return $this->payload();
+        return $this->task->getPayload();
     }
 
     public function payload(): array

--- a/tests/Unit/Queue/RoadRunnerJobTest.php
+++ b/tests/Unit/Queue/RoadRunnerJobTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunnerLaravel\Tests\Unit\Queue;
+
+use Illuminate\Contracts\Foundation\Application;
+use PHPUnit\Framework\TestCase;
+use Spiral\RoadRunner\Jobs\Task\ReceivedTaskInterface;
+use Spiral\RoadRunnerLaravel\Queue\RoadRunnerJob;
+
+final class RoadRunnerJobTest extends TestCase
+{
+    public function test_get_raw_body_returns_the_wire_payload_string_verbatim(): void
+    {
+        // Deliberately use non-canonical JSON (spaces after `:` and `,`) so a
+        // regression that round-trips through json_decode + json_encode would
+        // produce different bytes and fail the byte-identity assertion below.
+        $wirePayload = '{"job": "Illuminate\\\\Queue\\\\CallQueuedHandler@call", "data": {"commandName": "App\\\\Jobs\\\\Demo"}}';
+
+        $task = $this->createMock(ReceivedTaskInterface::class);
+        $task->method('getPayload')->willReturn($wirePayload);
+
+        $job = new RoadRunnerJob($this->createMock(Application::class), $task);
+
+        $body = $job->getRawBody();
+
+        self::assertIsString(
+            $body,
+            'getRawBody() is part of the Illuminate\\Contracts\\Queue\\Job contract and MUST return a string.',
+        );
+        self::assertSame(
+            $wirePayload,
+            $body,
+            'getRawBody() should return the raw bytes the task carried on the wire, not a re-encoded version.',
+        );
+    }
+
+    public function test_get_raw_body_is_consistent_with_decoded_payload(): void
+    {
+        // Sanity-check that getRawBody() and payload() agree on the data they
+        // describe — they're two views of the same body (string vs decoded
+        // array), and any divergence here would mean failure handlers
+        // (FailingJob), tracing integrations, and retry serialization all see
+        // different pictures of the same job.
+        $wirePayload = '{"job":"X","data":{"foo":"bar"},"attempts":0}';
+
+        $task = $this->createMock(ReceivedTaskInterface::class);
+        $task->method('getPayload')->willReturn($wirePayload);
+
+        $job = new RoadRunnerJob($this->createMock(Application::class), $task);
+
+        self::assertSame($wirePayload, $job->getRawBody());
+        self::assertSame(
+            \json_decode($job->getRawBody(), true),
+            $job->payload(),
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`Spiral\RoadRunnerLaravel\Queue\RoadRunnerJob::getRawBody()` is declared `: string`, but its body returns `$this->payload()` — which is declared `: array`. PHP refuses to coerce one to the other for return types, so any caller hits a hard `TypeError`:

```
RoadRunnerJob::getRawBody(): Return value must be of type string, array returned
```

`getRawBody()` is part of the `Illuminate\Contracts\Queue\Job` contract, not internal-only, and is invoked from several stable code paths in any real Laravel app:

- **Laravel core** — `Illuminate\Queue\FailingJob::handle()` calls `$job->getRawBody()` to persist the body into the `failed_jobs` table the moment any job throws.
- **Sentry's `QueueIntegration`** — attaches the raw body to queue breadcrumbs / transactions when its queue integration is enabled (default).
- **Laravel Telescope** — captures it for the Jobs panel.
- **`SerializesAndRestoresModelIdentifiers`** — walks the body on retry to re-hydrate `SerializesModels` properties.

Net effect: against this bridge today, every failed job in production crashes the worker before Laravel can record the failure, every Sentry-instrumented job dispatches an exception event, and Telescope captures nothing.

## Fix

Return `$this->task->getPayload()`. The constructor already keeps the `ReceivedTaskInterface` on `$this->task`, so the original wire bytes are available with zero re-encoding. The fix matches:

- the declared return type (`string`),
- the semantic of the method name (the *raw* body, untouched),
- equivalent implementations across core Laravel queue drivers (`RedisJob`, `DatabaseJob`, `BeanstalkdJob`, `SqsJob` — each returns the raw string it received from its transport).

## Diff

```diff
 public function getRawBody(): string
 {
-    return $this->payload();
+    return $this->task->getPayload();
 }
```

## How users hit this in the wild

On a NATS-backed task, the `JobProcessing` event handler reaches `getRawBody()`, throws, the bridge releases the task, NATS redelivers, repeat. Hundreds of thousands of release cycles before the `delete_after_ack` window finally drops the message.

## Test plan

- [x] New unit test covers `getRawBody()` return type and byte identity with the task payload (commit e713cb5).
- [ ] Reviewer: confirm CI passes on the PR branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where queue job payloads were being returned incorrectly, ensuring the correct raw payload is now retrieved from the underlying source.

* **Tests**
  * Added tests to validate queue job payload handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-php/laravel-bridge/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->