### PR TITLE
chore: repair broken phpunit and phpstan configs

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,8 +3,6 @@ parameters:
   paths:
     - bin/rr-worker
     - config
-    - fixes
-    - helpers
     - src
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:


### PR DESCRIPTION
## Problem

Two of the repo's tool configs point at directories that do not exist, so the tools fail before they can run:

```
$ composer test
Test directory "./tests/Feature" not found
```

```
$ composer phpstan
Path /.../fixes does not exist
```

`phpunit.xml.dist` declares a `Feature` testsuite at `./tests/Feature` (does not exist). `phpstan.neon.dist` lists `fixes` and `helpers` in its `paths:` (neither exists). Both have been broken at the config level long enough that there is no automation enforcing them — the repo has only `cs-fix.yml` and Dependabot in CI, no test or phpstan workflow.

Net effect: anyone running `composer test` or `composer phpstan` locally hits an error before any analysis happens. `composer test:unit` (which scopes to just the existing `Unit` suite) is the only path that worked.

## Fix

Two one-shot changes, kept intentionally minimal:

- Stub `tests/Feature/` with a `.gitkeep`. Preserves the maintainer's original two-suite intent and keeps `composer test:feat` meaningful for when feature tests get added later. Could also have been "remove the Feature testsuite from the config," but stubbing is the smaller signal.
- Drop `fixes` and `helpers` from `phpstan.neon.dist`'s `paths:`. They do not exist in the repo, so they cannot be analyzed.

## After this PR

- `composer test` runs cleanly — 2 tests, 4 assertions, all pass.
- `composer phpstan` runs and reports **119 pre-existing errors** that have been accumulating invisibly because phpstan was dying before scanning. This PR intentionally does **not** fix those errors. The point here is to unblock the tool; how to handle the 119 is a workflow question for the maintainer.

## Question for the maintainer

Now that phpstan can actually run, what direction would you like for the 119 errors? Happy to send a follow-up PR for whichever you prefer:

- (a) Generate a phpstan baseline (`phpstan-baseline.neon`) so phpstan is green from now on and only new errors fail. Existing errors get grandfathered and can be chipped away at over time.
- (b) Address errors in topical batches across several small PRs (missing iterable annotations, then mixed-return narrowings, then protobuf DTO assertions, etc.).
- (c) Drop the `level: 'max'` setting to something more achievable in the short term and tighten later.

Or some combination. I do not want to guess your workflow preference, so I have left it alone in this PR.

## Test plan

- [x] `composer test` runs without error (2/2 pass).
- [x] `composer test:unit` continues to work (no regression on the previously-functional path).
- [x] `composer phpstan` executes (no longer dies on a missing path).
- [x] `composer cs:check` clean.

## Related

While preparing this I also noticed the `ignoreErrors` block in `phpstan.neon.dist` references two files that no longer exist in the repo (`src/Application/Factory.php`, `src/Listeners/ResetLaravelIgnitionListener.php`). `reportUnmatchedIgnoredErrors: false` is masking that fact. Left untouched here — the dead rules do not cause harm (they ignore nothing). Happy to clean those up in the same follow-up that addresses the phpstan errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tooling configuration to refine analysis scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/roadrunner-php/laravel-bridge/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->